### PR TITLE
Bump to handlebars-1.0.0-rc.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>1.0.rc.1</upstreamVersion>
-        <upstreamSourceUrl>http://cloud.github.com/downloads/wycats/handlebars.js</upstreamSourceUrl>
+        <upstreamVersion>1.0.0-rc.3</upstreamVersion>
+        <upstreamSourceUrl>http://cdnjs.cloudflare.com/ajax/libs/handlebars.js</upstreamSourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>
 
@@ -58,8 +58,8 @@
                         <phase>process-resources</phase>
                         <goals><goal>download-single</goal></goals>
                         <configuration>
-                            <url>${upstreamSourceUrl}</url>
-                            <fromFile>handlebars-${upstreamVersion}.js</fromFile>
+                            <url>${upstreamSourceUrl}/${upstreamVersion}</url>
+                            <fromFile>handlebars.js</fromFile>
                             <toFile>${destDir}/handlebars.js</toFile>
                         </configuration>
                     </execution>
@@ -68,8 +68,8 @@
                         <phase>process-resources</phase>
                         <goals><goal>download-single</goal></goals>
                         <configuration>
-                            <url>${upstreamSourceUrl}</url>
-                            <fromFile>handlebars-${upstreamVersion}.min.js</fromFile>
+                            <url>${upstreamSourceUrl}/${upstreamVersion}</url>
+                            <fromFile>handlebars.min.js</fromFile>
                             <toFile>${destDir}/handlebars.min.js</toFile>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Also use cdnjs for source URL because they have up-to-date minified and
non-minified files for various JS projects (the handlebars.js downloads
is 5 months behind)
