### PR TITLE
update version to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>handlebars</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>Handlebars</name>
     <description>WebJar for Handlebars</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>1.1.2</upstreamVersion>
+        <upstreamVersion>1.2.1</upstreamVersion>
         <upstreamSourceUrl>http://cdnjs.cloudflare.com/ajax/libs/handlebars.js</upstreamSourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>
     </properties>


### PR DESCRIPTION
it is also dependency for Ember.js 1.3.1
After this change I can send pull request for Ember.js update.
